### PR TITLE
Change template for image picker widget

### DIFF
--- a/app/design/adminhtml/default/default/layout/dull_uploader.xml
+++ b/app/design/adminhtml/default/default/layout/dull_uploader.xml
@@ -31,4 +31,16 @@
             </action>
         </reference>
     </adminhtml_cms_wysiwyg_images_index>
+    <!--
+     To make it compatible with image picker aijko-widgetimagechooser
+     https://github.com/aijko/aijko-widgetimagechooser
+     https://github.com/aligent/aijko-widgetimagechooser
+     -->
+    <adminhtml_cms_wysiwyg_images_chooser_index>
+        <reference name="wysiwyg_images.uploader">
+            <action method="setTemplate">
+                <template>dull/uploader/cms_uploader.phtml</template>
+            </action>
+        </reference>
+    </adminhtml_cms_wysiwyg_images_chooser_index>
 </layout>


### PR DESCRIPTION
These changes make the extension compatible with image picker widget.
Even though each project can inject this code in their local, 
this results in a better out of the box experience.
