### PR TITLE
Added more support for the image picker widget

### DIFF
--- a/app/design/adminhtml/default/default/layout/dull_uploader.xml
+++ b/app/design/adminhtml/default/default/layout/dull_uploader.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <layout>
-    <editor>
+    <dull_uploader>
         <reference name="head">
             <action method="removeItem">
                 <type>js</type>
@@ -23,6 +23,9 @@
                 <name>dull/uploader/uploader.js</name>
             </action>
         </reference>
+    </dull_uploader>
+    <editor>
+        <update handle="dull_uploader"/>
     </editor>
     <adminhtml_cms_wysiwyg_images_index>
         <reference name="wysiwyg_images.uploader">
@@ -36,6 +39,9 @@
      https://github.com/aijko/aijko-widgetimagechooser
      https://github.com/aligent/aijko-widgetimagechooser
      -->
+    <adminhtml_widget_instance_edit>
+        <update handle="dull_uploader"/>
+    </adminhtml_widget_instance_edit>
     <adminhtml_cms_wysiwyg_images_chooser_index>
         <reference name="wysiwyg_images.uploader">
             <action method="setTemplate">


### PR DESCRIPTION
The original commit, 95e26e3 (PR #9), did add support for the image picker widget on editor pages, but didn't on the Widget Instance Edit pages. I chose to create a separate layout handle that replaces all JS files and apply that handle to both editor and widget instance edit pages.
